### PR TITLE
Run on PHP 8.1+ by moving off the pre-PHP-8 dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,26 +14,15 @@
     {
       "type": "vcs",
       "url": "https://github.com/ictinnovations/RestServer"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/ictinnovations/ProcessManager"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/ictinnovations/office-converter"
     }
   ],
   "require": {
-    "swiftmailer/swiftmailer": "^5.4.8",
-    "nategood/httpful": "^0.2.20",
-    "aza/thread": "^1.1",
-    "twig/twig": "^1.35",
+    "php": ">=8.1",
+    "symfony/mailer": "^6.4",
+    "twig/twig": "^3.0",
     "jacwright/restserver": "dev-master",
-    "firebase/php-jwt": "^5.0",
-    "firehed/processmanager": "dev-master",
-    "ncjoes/office-converter": "dev-master",
-    "dompdf/dompdf": "^0.8.3"
+    "firebase/php-jwt": "^7.0",
+    "dompdf/dompdf": "^3.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,108 +4,36 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95e563eecf9988201704aa120c545ece",
+    "content-hash": "3af8590dc2a4f43965a6aa5f2593f5e6",
     "packages": [
         {
-            "name": "aza/clibase",
-            "version": "v1.1",
-            "target-dir": "Aza/Components/CliBase",
+            "name": "doctrine/lexer",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Anizoptera/AzaCliBase.git",
-                "reference": "6b2e2bc84416e991741472d24cd87ce85416d597"
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Anizoptera/AzaCliBase/zipball/6b2e2bc84416e991741472d24cd87ce85416d597",
-                "reference": "6b2e2bc84416e991741472d24cd87ce85416d597",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "aza/libevent": "Used for storing one main event base for application",
-                "ext-libevent": "Used for storing one main event base for application and save availability flag",
-                "ext-pcntl": "Used everywhere in component. Really it's a requirement for normal work.",
-                "ext-posix": "Used everywhere in component. Really it's a requirement for normal work.",
-                "ext-proctitle": "Used to change process title"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Aza\\Components\\CliBase": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Amal Samally",
-                    "email": "amal.samally@gmail.com",
-                    "homepage": "https://github.com/amal"
-                },
-                {
-                    "name": "AzaGroup Members"
-                }
-            ],
-            "description": "AzaCliBase - Anizoptera CMF component with basic functionality and helper methods for CLI and Daemon applications (forks, libevent, etc..).",
-            "homepage": "https://github.com/Anizoptera/AzaCliBase",
-            "keywords": [
-                "cli",
-                "daemon",
-                "exit code",
-                "fork",
-                "helper",
-                "libevent",
-                "pcntl",
-                "posix",
-                "signal",
-                "utility"
-            ],
-            "time": "2013-05-28T13:02:20+00:00"
-        },
-        {
-            "name": "aza/libevent",
-            "version": "v1.1",
-            "target-dir": "Aza/Components/LibEvent",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Anizoptera/AzaLibEvent.git",
-                "reference": "de193b1fd8865878d79693c86cbea594996e82c0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Anizoptera/AzaLibEvent/zipball/de193b1fd8865878d79693c86cbea594996e82c0",
-                "reference": "de193b1fd8865878d79693c86cbea594996e82c0",
-                "shasum": ""
-            },
-            "require": {
-                "aza/clibase": "~1.0",
-                "php": ">=5.2"
+                "php": "^8.1"
             },
             "require-dev": {
-                "aza/socket": "~1.0"
-            },
-            "suggest": {
-                "ext-libevent": "Really it's a requirement for normal work."
+                "doctrine/coding-standard": "^12",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.5",
+                "psalm/plugin-phpunit": "^0.18.3",
+                "vimeo/psalm": "^5.21"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "Aza\\Components\\LibEvent": ""
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -114,121 +42,237 @@
             ],
             "authors": [
                 {
-                    "name": "Amal Samally",
-                    "email": "amal.samally@gmail.com",
-                    "homepage": "https://github.com/amal"
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
-                    "name": "AzaGroup Members"
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
                 }
             ],
-            "description": "AzaLibEvent - Simple, powerful and easy to use OOP wrapper for the LibEvent PHP bindings. Component from Anizoptera CMF.",
-            "homepage": "https://github.com/Anizoptera/AzaLibEvent",
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
             "keywords": [
-                "async",
-                "event",
-                "libevent",
-                "sockets",
-                "stream",
-                "timers"
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
             ],
-            "time": "2013-05-28T13:02:36+00:00"
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-05T11:56:58+00:00"
         },
         {
-            "name": "aza/socket",
-            "version": "v1.0.2",
-            "target-dir": "Aza/Components/Socket",
+            "name": "dompdf/dompdf",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Anizoptera/AzaSocket.git",
-                "reference": "c8b048206b2b5e700121629a79f9c4061378551e"
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "6d4b4eb8500f7a786da8868ba463a71b725a4005"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Anizoptera/AzaSocket/zipball/c8b048206b2b5e700121629a79f9c4061378551e",
-                "reference": "c8b048206b2b5e700121629a79f9c4061378551e",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/6d4b4eb8500f7a786da8868ba463a71b725a4005",
+                "reference": "6d4b4eb8500f7a786da8868ba463a71b725a4005",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
             },
             "suggest": {
-                "ext-sockets": "Used for maximum efficiency"
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "Aza\\Components\\Socket": ""
-                }
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "LGPL-2.1"
             ],
             "authors": [
                 {
-                    "name": "Amal Samally",
-                    "email": "amal.samally@gmail.com",
-                    "homepage": "https://github.com/amal"
-                },
-                {
-                    "name": "AzaGroup Members"
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
                 }
             ],
-            "description": "AzaSocket - Anizoptera CMF sockets abstraction component. Provides convenient universal API for using sockets in PHP (via sockets or stream extensions).",
-            "homepage": "https://github.com/Anizoptera/AzaSocket",
-            "keywords": [
-                "Socket",
-                "accept",
-                "client",
-                "non-block",
-                "pair",
-                "server",
-                "tcp",
-                "unix"
-            ],
-            "time": "2013-05-28T13:05:06+00:00"
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.6"
+            },
+            "time": "2026-07-20T12:29:38+00:00"
         },
         {
-            "name": "aza/thread",
-            "version": "v1.1",
-            "target-dir": "Aza/Components/Thread",
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Anizoptera/AzaThread.git",
-                "reference": "594c535b3644f871c98639625d72a44f7d7b334f"
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Anizoptera/AzaThread/zipball/594c535b3644f871c98639625d72a44f7d7b334f",
-                "reference": "594c535b3644f871c98639625d72a44f7d7b334f",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a",
                 "shasum": ""
             },
             "require": {
-                "aza/clibase": "~1.0",
-                "aza/libevent": "~1.0",
-                "aza/socket": "~1.0",
-                "php": ">=5.3.3"
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11 || ^12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.2"
+            },
+            "time": "2026-01-20T14:10:26+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4 || ^9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.2"
+            },
+            "time": "2026-01-02T16:01:13+00:00"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "php": ">=8.1",
+                "symfony/polyfill-intl-idn": "^1.26"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.2",
+                "vimeo/psalm": "^5.12"
             },
             "suggest": {
-                "ext-libevent": "Only synchronous compatibility mode will be available without it",
-                "ext-pcntl": "Only synchronous compatibility mode will be available without it",
-                "ext-posix": "Only synchronous compatibility mode will be available without it"
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Aza\\Components\\Thread": ""
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -237,46 +281,61 @@
             ],
             "authors": [
                 {
-                    "name": "Amal Samally",
-                    "email": "amal.samally@gmail.com",
-                    "homepage": "https://github.com/amal"
-                },
-                {
-                    "name": "AzaGroup Members"
+                    "name": "Eduardo Gulias Davis"
                 }
             ],
-            "description": "AzaThread - Anizoptera CMF simple and powerful threads emulation component for PHP (based on forks).",
-            "homepage": "https://github.com/Anizoptera/AzaThread",
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
             "keywords": [
-                "Multi-thread",
-                "Thread",
-                "async",
-                "daemon",
-                "fork",
-                "parallel",
-                "serialization"
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
             ],
-            "time": "2013-05-28T13:05:37+00:00"
+            "support": {
+                "issues": "https://github.com/egulias/EmailValidator/issues",
+                "source": "https://github.com/egulias/EmailValidator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/egulias",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-06T22:45:56+00:00"
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v5.0.0",
+            "version": "v7.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "9984a4d3a32ae7673d6971ea00bae9d0a1abba0e"
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/9984a4d3a32ae7673d6971ea00bae9d0a1abba0e",
-                "reference": "9984a4d3a32ae7673d6971ea00bae9d0a1abba0e",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": " 4.8.35"
+                "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
+                "phpseclib/phpseclib": "~3.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present",
+                "phpseclib/phpseclib": "Support PS256 (RSASSA-PSS) signatures"
             },
             "type": "library",
             "autoload": {
@@ -301,43 +360,16 @@
                 }
             ],
             "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
-            "homepage": "https://github.com/firebase/php-jwt",
-            "time": "2017-06-27T22:17:23+00:00"
-        },
-        {
-            "name": "firehed/processmanager",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ictinnovations/ProcessManager.git",
-                "reference": "8c6b261365457b83d7ef4fc70f3bce5c1347ba4b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ictinnovations/ProcessManager/zipball/8c6b261365457b83d7ef4fc70f3bce5c1347ba4b",
-                "reference": "8c6b261365457b83d7ef4fc70f3bce5c1347ba4b",
-                "shasum": ""
-            },
-            "require": {
-                "ext-pcntl": "*",
-                "ext-posix": "*",
-                "php": ">=5.3.0",
-                "psr/log": ">=1.0.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Firehed\\ProcessControl\\": "src/"
-                }
-            },
-            "license": [
-                "MIT"
+            "homepage": "https://github.com/googleapis/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
             ],
-            "description": "Simple base for daemonized wokers",
             "support": {
-                "source": "https://github.com/ictinnovations/ProcessManager/tree/master"
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.1.0"
             },
-            "time": "2017-12-18T16:12:24+00:00"
+            "time": "2026-06-11T17:54:14+00:00"
         },
         {
             "name": "jacwright/restserver",
@@ -345,17 +377,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ictinnovations/RestServer.git",
-                "reference": "2b99afbd9702795fea78eeb0ce7797df6bd8b8bf"
+                "reference": "0a09d5b1537b205d40a42312561367889eb761a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ictinnovations/RestServer/zipball/2b99afbd9702795fea78eeb0ce7797df6bd8b8bf",
-                "reference": "2b99afbd9702795fea78eeb0ce7797df6bd8b8bf",
+                "url": "https://api.github.com/repos/ictinnovations/RestServer/zipball/0a09d5b1537b205d40a42312561367889eb761a4",
+                "reference": "0a09d5b1537b205d40a42312561367889eb761a4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-0": {
@@ -387,33 +420,38 @@
             "support": {
                 "source": "https://github.com/ictinnovations/RestServer/tree/master"
             },
-            "time": "2017-12-23T13:24:13+00:00"
+            "time": "2020-05-18T12:02:54+00:00"
         },
         {
-            "name": "nategood/httpful",
-            "version": "0.2.20",
+            "name": "masterminds/html5",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/nategood/httpful.git",
-                "reference": "c1cd4d46a4b281229032cf39d4dd852f9887c0f6"
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nategood/httpful/zipball/c1cd4d46a4b281229032cf39d4dd852f9887c0f6",
-                "reference": "c1cd4d46a4b281229032cf39d4dd852f9887c0f6",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fd5018f6815fff903946d0564977b44ce8010e29",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29",
                 "shasum": ""
             },
             "require": {
-                "ext-curl": "*",
-                "php": ">=5.3"
+                "ext-dom": "*",
+                "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "*"
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9 || ^10"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "Httpful": "src/"
+                "psr-4": {
+                    "Masterminds\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -422,84 +460,104 @@
             ],
             "authors": [
                 {
-                    "name": "Nate Good",
-                    "email": "me@nategood.com",
-                    "homepage": "http://nategood.com"
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
                 }
             ],
-            "description": "A Readable, Chainable, REST friendly, PHP HTTP Client",
-            "homepage": "http://github.com/nategood/httpful",
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
             "keywords": [
-                "api",
-                "curl",
-                "http",
-                "requests",
-                "rest",
-                "restful"
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
             ],
-            "time": "2015-10-26T16:11:30+00:00"
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.1"
+            },
+            "time": "2026-06-23T18:43:15+00:00"
         },
         {
-            "name": "ncjoes/office-converter",
-            "version": "dev-master",
+            "name": "psr/container",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/ictinnovations/office-converter.git",
-                "reference": "b85b0a6c40cd5d89bbf777cec4d77f1ee7256dcb"
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ictinnovations/office-converter/zipball/b85b0a6c40cd5d89bbf777cec4d77f1ee7256dcb",
-                "reference": "b85b0a6c40cd5d89bbf777cec4d77f1ee7256dcb",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "5.4.*"
+                "php": ">=7.4.0"
             },
             "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "NcJoes\\OfficeConverter\\": "src/OfficeConverter"
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
                 }
             },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "authors": [
                 {
-                    "name": "Chukwuemeka Nwobodo",
-                    "email": "jc.nwobodo@gmail.com"
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
-            "description": "PHP Wrapper for LibreOffice",
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
             "keywords": [
-                "Converter",
-                "Office"
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
             ],
             "support": {
-                "source": "https://github.com/ictinnovations/office-converter/tree/master"
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2018-08-31T10:55:57+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
-            "name": "psr/log",
-            "version": "1.0.2",
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
             "extra": {
@@ -509,7 +567,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\EventDispatcher\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -522,6 +580,56 @@
                     "homepage": "http://www.php-fig.org/"
                 }
             ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
             "description": "Common interface for logging libraries",
             "homepage": "https://github.com/php-fig/log",
             "keywords": [
@@ -529,38 +637,121 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
-            "name": "swiftmailer/swiftmailer",
-            "version": "v5.4.8",
+            "name": "sabberworm/php-css-parser",
+            "version": "v9.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "9a06dc570a0367850280eefd3f1dc2da45aef517"
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/9a06dc570a0367850280eefd3f1dc2da45aef517",
-                "reference": "9a06dc570a0367850280eefd3f1dc2da45aef517",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f",
+                "reference": "fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "ext-iconv": "*",
+                "php": "^7.2.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "thecodingmachine/safe": "^1.3 || ^2.5 || ^3.4"
             },
             "require-dev": {
-                "mockery/mockery": "~0.9.1",
-                "symfony/phpunit-bridge": "~3.2"
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/extension-installer": "1.4.3",
+                "phpstan/phpstan": "1.12.33 || 2.2.2",
+                "phpstan/phpstan-phpunit": "1.4.2 || 2.0.16",
+                "phpstan/phpstan-strict-rules": "1.6.2 || 2.0.11",
+                "phpunit/phpunit": "8.5.52",
+                "rawr/phpunit-data-provider": "3.3.1",
+                "rector/rector": "1.2.10 || 2.4.6",
+                "rector/type-perfect": "1.0.0 || 2.1.3",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "thecodingmachine/phpstan-safe-rule": "1.2.0 || 1.4.3"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.4-dev"
+                    "dev-main": "9.5.x-dev"
                 }
             },
             "autoload": {
                 "files": [
-                    "lib/swift_required.php"
+                    "src/Rule/Rule.php",
+                    "src/RuleSet/RuleContainer.php"
+                ],
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v9.4.0"
+            },
+            "time": "2026-06-18T15:10:53+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -569,54 +760,981 @@
             ],
             "authors": [
                 {
-                    "name": "Chris Corbyn"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Swiftmailer, free feature-rich PHP mailer",
-            "homepage": "http://swiftmailer.org",
-            "keywords": [
-                "email",
-                "mail",
-                "mailer"
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
-            "time": "2017-05-01T15:54:03+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
-            "name": "twig/twig",
-            "version": "v1.35.0",
+            "name": "symfony/event-dispatcher",
+            "version": "v7.4.15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/twigphp/Twig.git",
-                "reference": "daa657073e55b0a78cce8fdd22682fddecc6385f"
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "336e7f3b9e95aba04f93ea9143920c2186abfbb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/daa657073e55b0a78cce8fdd22682fddecc6385f",
-                "reference": "daa657073e55b0a78cce8fdd22682fddecc6385f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/336e7f3b9e95aba04f93ea9143920c2186abfbb9",
+                "reference": "336e7f3b9e95aba04f93ea9143920c2186abfbb9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=8.2",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
             },
             "require-dev": {
-                "psr/container": "^1.0",
-                "symfony/debug": "~2.7",
-                "symfony/phpunit-bridge": "~3.3@dev"
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.15"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-21T15:13:06+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c7de7a00ffb67842132da02ea92988a39ccd9f4e",
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1"
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
-                    "dev-master": "1.35-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Twig_": "lib/"
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
+            "name": "symfony/mailer",
+            "version": "v6.4.43",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mailer.git",
+                "reference": "2a380924b56e034076c4a658d40e140ba150e44c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/2a380924b56e034076c4a658d40e140ba150e44c",
+                "reference": "2a380924b56e034076c4a658d40e140ba150e44c",
+                "shasum": ""
+            },
+            "require": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1",
+                "psr/log": "^1|^2|^3",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/mime": "^6.2|^7.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<5.4",
+                "symfony/messenger": "<6.2",
+                "symfony/mime": "<6.2",
+                "symfony/twig-bridge": "<6.2.1"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/http-client": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^6.2|^7.0",
+                "symfony/twig-bridge": "^6.2|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps sending emails",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/mailer/tree/v6.4.43"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-27T19:43:14+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v7.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "20094b76a7106dbe978d31cd3bd7aa1ed248d0e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/20094b76a7106dbe978d31cd3bd7aa1ed248d0e5",
+                "reference": "20094b76a7106dbe978d31cd3bd7aa1ed248d0e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "egulias/email-validator": "~3.0.0",
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/mailer": "<6.4",
+                "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3.1|^4",
+                "league/html-to-markdown": "^5.0",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4.3|^7.0.3|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows manipulating MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v7.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-07T14:56:57+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "symfony/polyfill-intl-normalizer": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T15:22:23+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.38.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:48:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:59:30+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-16T09:55:08+00:00"
+        },
+        {
+            "name": "thecodingmachine/safe",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^10",
+                "squizlabs/php_codesniffer": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/special_cases.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gettext.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/mysql.php",
+                    "generated/mysqli.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rnp.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ],
+                "classmap": [
+                    "lib/DateTime.php",
+                    "lib/DateTimeImmutable.php",
+                    "lib/Exceptions/",
+                    "generated/Exceptions/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/OskarStark",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/shish",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/silasjoisten",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-04T18:08:13+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v3.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "597c12ed286fb9d1701a36684ce6e0cbe28ebc8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/597c12ed286fb9d1701a36684ce6e0cbe28ebc8b",
+                "reference": "597c12ed286fb9d1701a36684ce6e0cbe28ebc8b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
+                "psr/container": "^1.0|^2.0",
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
                 "psr-4": {
                     "Twig\\": "src/"
                 }
@@ -633,34 +1751,48 @@
                     "role": "Lead Developer"
                 },
                 {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
                     "name": "Armin Ronacher",
                     "email": "armin.ronacher@active-4.com",
                     "role": "Project Founder"
-                },
-                {
-                    "name": "Twig Team",
-                    "homepage": "http://twig.sensiolabs.org/contributors",
-                    "role": "Contributors"
                 }
             ],
             "description": "Twig, the flexible, fast, and secure template language for PHP",
-            "homepage": "http://twig.sensiolabs.org",
+            "homepage": "https://twig.symfony.com",
             "keywords": [
                 "templating"
             ],
-            "time": "2017-09-27T18:06:46+00:00"
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v3.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-03T20:44:34+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "jacwright/restserver": 20,
-        "firehed/processmanager": 20,
-        "ncjoes/office-converter": 20
+        "jacwright/restserver": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": []
+    "platform": {
+        "php": ">=8.1"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/core/Api/ForgotpasswordApi.php
+++ b/core/Api/ForgotpasswordApi.php
@@ -20,11 +20,6 @@ use ICT\Core\CoreException;
 use Firebase\JWT\ExpiredException;
 use ICT\Core\Provider\Smtp;
 use ICT\Core\Request;
-use Swift_Attachment;
-use Swift_Mailer;
-use Swift_Message;
-use Swift_SendmailTransport;
-use Swift_SmtpTransport;
 
 #[\AllowDynamicProperties]
 class ForgotpasswordApi extends Api

--- a/core/Forgot_password.php
+++ b/core/Forgot_password.php
@@ -17,10 +17,13 @@ use Firebase\JWT\JWT;
 use ICT\Core\Corelog;
 use ICT\Core\CoreException;
 use Firebase\JWT\ExpiredException;
-use Swift_Mailer;
-use Swift_Message;
-use Swift_SendmailTransport;
-use Swift_SmtpTransport;
+use Firebase\JWT\Key;
+use Firebase\JWT\SignatureInvalidException;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
 use ICT\Core\Conf;
 use ICT\Core\Gateway\Sendmail;
 
@@ -71,24 +74,27 @@ class Forgot_password
         $body = str_replace(['[link]'], $link, $templateBody);
         $body = str_replace('[first_name]', $aValue['first_name'], $body);
         $route = Sendmail::default_route();
-        $transport = (new Swift_SmtpTransport($route->host, $route->port))
+        $transport = (new EsmtpTransport($route->host, (int) $route->port))
           ->setUsername($route->username)
           ->setPassword($route->password);
         // Create the Mailer using created Transport
-        $mailer = new Swift_Mailer($transport);
+        $mailer = new Mailer($transport);
         // Create a message
-        $message = (new Swift_Message('Forgot Password Request'))
-          ->setFrom(['kashif@ictinnovations.com' => 'ICT Fax'])
-          ->setTo($email)
-          ->setBody($body, 'text/html');
-        // return $message;
-        $result = $mailer->send($message);
-        if ($result) {
-          return true;
-          Corelog::log('email ' . print_r($result, true), Corelog::INFO);
-        } else {
+        $message = (new Email())
+          ->subject('Forgot Password Request')
+          ->from(new Address('kashif@ictinnovations.com', 'ICT Fax'))
+          ->to($email)
+          ->html($body);
+        // Symfony's send() returns void and signals failure by throwing, unlike
+        // Swift which returned a recipient count. Testing the return value here
+        // would report every successful send as a failure.
+        try {
+          $mailer->send($message);
+        } catch (TransportExceptionInterface $send_error) {
+          Corelog::log('email send failed: ' . $send_error->getMessage(), Corelog::ERROR);
           throw new CoreException(500, 'Error while sending mail');
         }
+        return true;
       } else {
         throw new CoreException(401, 'The provided email is not registered in our system. Please enter a valid email address.');
       }
@@ -153,7 +159,7 @@ class Forgot_password
       $key_file = Conf::get('security:public_key', '/usr/ictcore/etc/ssh/ib_node.pub');
       $hash_type = Conf::get('security:hash_type', 'RS256');
       $public_key = file_get_contents($key_file);
-      return JWT::decode($token, $public_key, array($hash_type));   
+      return JWT::decode($token, new Key($public_key, $hash_type));
     } catch (ExpiredException $e) {
       // Handle token expiration
       return false;

--- a/core/Gateway/Sendmail.php
+++ b/core/Gateway/Sendmail.php
@@ -18,15 +18,11 @@ use ICT\Core\Provider;
 use ICT\Core\Provider\Smtp;
 use ICT\Core\Provider\Emailcmd;
 use ICT\Core\Request;
-use Swift_Attachment;
-use Swift_Mailer;
-use Swift_Message;
-use Swift_SendmailTransport;
-use Swift_SmtpTransport;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Transport\SendmailTransport;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Component\Mime\Email;
 use ICT\Core\Account\EAddress;
-
-global $path_root;
-require_once $path_root . '/vendor/swiftmailer/swiftmailer/lib/swift_required.php';
 
 class Sendmail extends Gateway
 {
@@ -78,10 +74,15 @@ class Sendmail extends Gateway
     switch ($this->oProvider->type) {
       case 'smtp':
         try {
-          $this->conn = Swift_SmtpTransport::newInstance($this->oProvider->host, $this->oProvider->port);
-          if (!empty($this->oProvider->encryption)) {
-            $this->conn->setEncryption($this->oProvider->encryption);
+          // Swift took the encryption name as a string after construction.
+          // Symfony decides it up front: true means implicit TLS on connect
+          // (smtps, usually 465), null means plain connect then STARTTLS if the
+          // server advertises it, which is what 'tls' meant to Swift.
+          $tls = null;
+          if (strtolower((string) $this->oProvider->encryption) === 'ssl') {
+            $tls = true;
           }
+          $this->conn = new EsmtpTransport($this->oProvider->host, (int) $this->oProvider->port, $tls);
           $this->conn->setUsername($this->oProvider->username);
           $this->conn->setPassword($this->oProvider->password);
         } catch (Exception $conn_error) {
@@ -91,7 +92,7 @@ class Sendmail extends Gateway
       case 'sendmail':
       default:
         try {
-          $this->conn = Swift_SendmailTransport::newInstance($this->oProvider->cli);
+          $this->conn = new SendmailTransport($this->oProvider->cli);
         } catch (Exception $conn_error) {
           throw new CoreException("500", "sendmail connection error", $conn_error);
         }
@@ -103,7 +104,12 @@ class Sendmail extends Gateway
   protected function dissconnect()
   {
     Corelog::log("Sendmail disconnect requested", Corelog::CRUD);
-    return $this->conn->stop();
+    // Only the SMTP transport holds a socket open. SendmailTransport pipes to a
+    // process per message and has no stop().
+    if ($this->conn && method_exists($this->conn, 'stop')) {
+      return $this->conn->stop();
+    }
+    return TRUE;
   }
 
   public function get()
@@ -122,27 +128,25 @@ class Sendmail extends Gateway
     // Convert json into data array
     $data = json_decode($command, TRUE);
 
-    $mailMsg = Swift_Message::newInstance();
+    $mailMsg = new Email();
 
     // TODO, make it functional $headers = $mailMsg->getHeaders();
     // $headers->addIdHeader('spool_id', $data['spool_id']);
 
     try {
-      $mailMsg->setTo($this->validate_email($data['to']));
-      $mailMsg->setFrom($this->validate_email($data['from']));
-      $mailMsg->setSubject($data['subject']);
-      $mailMsg->setBody($data['body'], 'text/html');
+      $mailMsg->to($this->validate_email($data['to']));
+      $mailMsg->from($this->validate_email($data['from']));
+      $mailMsg->subject($data['subject']);
+      $mailMsg->html($data['body']);
       if (!empty($data['body_alt'])) {
-        $mailMsg->addPart($data['body_alt'], 'text/plain');
+        $mailMsg->text($data['body_alt']);
       }
       // Optionally add attachments
       if (!empty($data['attachment'])) {
         $aAttachment = \ICT\Core\path_string_to_array($data['attachment']);
         foreach($aAttachment as $attachment) {
           if (is_file($attachment)) {
-            $oAttachment = Swift_Attachment::fromPath($attachment);
-            // $oAttachment->setFilename($data['file_title']);
-            $mailMsg->attach($oAttachment);
+            $mailMsg->attachFromPath($attachment);
           }
         }
       }
@@ -155,7 +159,7 @@ class Sendmail extends Gateway
     $this->connect();
     if ($this->conn) {
       try {
-        $oMailer = Swift_Mailer::newInstance($this->conn);
+        $oMailer = new Mailer($this->conn);
         $oMailer->send($mailMsg);
       } catch (Exception $send_error) {
         throw new CoreException("500", "error while sending email", $send_error);

--- a/core/Message/Document.php
+++ b/core/Message/Document.php
@@ -15,7 +15,6 @@ use ICT\Core\DB;
 use ICT\Core\Message;
 use ICT\Core\Session;
 use ICT\Core\User;
-use NcJoes\OfficeConverter\OfficeConverter;
 
 class Document extends Message
 {

--- a/core/Transmission.php
+++ b/core/Transmission.php
@@ -25,7 +25,6 @@ class Transmission
   const STATUS_FAILED = 'failed';
   const FAILED_STATUS = 'failed(dnc)';
   const STATUS_INVALID = 'invalid';
-  const FAILED_STATUS = 'failed(dnc)';
   const INTERNAL = 'internal'; // currently not in use
   const INBOUND = 'inbound';
   const OUTBOUND = 'outbound';

--- a/core/lib/CoreThread.php
+++ b/core/lib/CoreThread.php
@@ -9,10 +9,98 @@ namespace ICT\Core;
  * Mail : nasir@ictinnovations.com                                 *
  * *************************************************************** */
 
-use Aza\Components\Thread\Thread;
-
-class CoreThread extends Thread
+/**
+ * Background worker for cron driven task processing.
+ *
+ * This used to extend Aza\Components\Thread\Thread. aza/thread has no PHP 8
+ * release and is unmaintained, so the small part of its surface ICTCore relied
+ * on (wait, run, getParam, plus the onFork and onShutdown hooks) is implemented
+ * here directly on pcntl.
+ *
+ * Where pcntl is unavailable, notably under mod_php, work runs inline in the
+ * calling process. That matches how ICTCore already behaved: the note in
+ * Gateway/Sendmail::send records that multithreading does not work under apache,
+ * which is why transmissions are scheduled rather than forked there.
+ */
+abstract class CoreThread
 {
+
+  /** @var array $params arguments passed to the most recent run() */
+  private $params = array();
+
+  /**
+   * The unit of work. Implemented by each subclass, called once per run().
+   */
+  abstract protected function process();
+
+  /**
+   * Kept so existing callers can stay in the wait()->run() form.
+   */
+  public function wait()
+  {
+    return $this;
+  }
+
+  /**
+   * Runs process() in a forked child when possible, otherwise inline.
+   *
+   * The child is deliberately not waited on: callers loop over pending tasks and
+   * would otherwise serialise them. Children are reaped by ignoring SIGCHLD, so
+   * they do not accumulate as zombies for the lifetime of the cron process.
+   */
+  public function run(...$params)
+  {
+    $this->params = $params;
+
+    if (!self::can_fork()) {
+      $this->run_inline();
+      return $this;
+    }
+
+    pcntl_signal(SIGCHLD, SIG_IGN);
+    $pid = pcntl_fork();
+
+    if ($pid === -1) {
+      Corelog::log('fork failed, running ' . static::class . ' inline', Corelog::WARNING);
+      $this->run_inline();
+    } else if ($pid === 0) {
+      // Child. Must never return to the caller's control flow, and must not run
+      // the parent's shutdown handlers, hence exit() rather than return.
+      $code = 0;
+      try {
+        $this->onFork();
+        $this->process();
+        $this->onShutdown();
+      } catch (\Throwable $e) {
+        Corelog::log('thread ' . static::class . ' failed: ' . $e->getMessage(), Corelog::ERROR);
+        $code = 1;
+      }
+      exit($code);
+    }
+
+    return $this;
+  }
+
+  public function getParam($index, $default = null)
+  {
+    return array_key_exists($index, $this->params) ? $this->params[$index] : $default;
+  }
+
+  private function run_inline()
+  {
+    // No fork, so no new database connection and no pid change: calling
+    // onFork() here would reconnect the caller's own handle out from under it.
+    $this->process();
+    $this->onShutdown();
+  }
+
+  private static function can_fork()
+  {
+    return function_exists('pcntl_fork')
+        && function_exists('pcntl_signal')
+        && PHP_SAPI === 'cli';
+  }
+
   protected function onFork()
   {
     DB::$link = DB::connect(TRUE);

--- a/core/lib/Token.php
+++ b/core/lib/Token.php
@@ -9,8 +9,9 @@ namespace ICT\Core;
  * Mail : nasir@ictinnovations.com                                 *
  * **************************************************************** */
 
-use Twig_Environment;
-use Twig_Loader_Filesystem;
+use Twig\Environment;
+use Twig\Extension\EscaperExtension;
+use Twig\Loader\FilesystemLoader;
 
 class Token
 {
@@ -114,13 +115,18 @@ class Token
     $this->default_value = $default_value;
 
     /* ---------------------------------------------- PREPARE TEMPLATE ENGINE */
-    $loader = new Twig_Loader_Filesystem($template_dir); // template home dir
-    $twig = new Twig_Environment($loader, array(
+    $loader = new FilesystemLoader($template_dir); // template home dir
+    $twig = new Environment($loader, array(
         'autoescape' => false,
             // uncomment following line to enable cache
             // 'cache' => $path_cache,
     ));
-    $twig->getExtension('Twig_Extension_Core')->setEscaper('json', function($twigEnv, $string, $charset) {
+    // No template in this tree asks for the json strategy, but ICTCore is a
+    // library and the products built on it ship their own templates, so the
+    // strategy is kept rather than dropped. Twig 3 moved setEscaper off the core
+    // extension onto EscaperExtension; it still passes the environment as the
+    // first argument, so the callable keeps its original three parameters.
+    $twig->getExtension(EscaperExtension::class)->setEscaper('json', function($twigEnv, $string, $charset) {
         return addcslashes(str_replace("\r", '', $string), "\"\n\r");
     });
 

--- a/tests/client.php
+++ b/tests/client.php
@@ -1,8 +1,9 @@
 <?php
 
-require(__DIR__ . '/../vendor/nategood/httpful/bootstrap.php');
+// Uses ext-curl directly. This used to pull in nategood/httpful, which has no
+// PHP 8 release and was only ever needed by these two example scripts.
 
-// STEP 1: configure API function to connect and authenticate with ICTBroadcast server
+// STEP 1: configure API function to connect and authenticate with ICTCore server
 function ictcore_api($method, $arguments = array(), $files = array()) {
   $api_url  = 'http://core.voip.vision';
   $username = 'admin';
@@ -10,31 +11,44 @@ function ictcore_api($method, $arguments = array(), $files = array()) {
   $service_url = "$api_url/$method";
   echo $service_url."\n";
 
-  $request = \Httpful\Request::post($service_url); // Build a PUT request...
-  $request->expectsJson();                             // and also receiving in json
-  $request->sendsJson();
-  $request->authenticateWith($username, $password);    // authenticate with basic auth...
+  $headers = array('Accept: application/json');
 
-  // json is not supported with file upload
   if (empty($files)) {
-    $request->body(json_encode($arguments), Httpful\Mime::JSON);
+    $payload   = json_encode($arguments);
+    $headers[] = 'Content-Type: application/json';
   } else {
-    $request->sendsType(Httpful\Mime::UPLOAD);
-    $request->alwaysSerializePayload();
-    $request->body($arguments); // no JSON
-    $request->attach($files);
+    // json is not supported with file upload, so send multipart instead and let
+    // curl set the Content-Type with its own boundary.
+    $payload = $arguments;
+    foreach ($files as $field => $path) {
+      $payload[$field] = new CURLFile($path);
+    }
   }
 
-  $response = $request->send();            // attach a body/payload...
+  $ch = curl_init($service_url);
+  curl_setopt_array($ch, array(
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST           => true,
+    CURLOPT_POSTFIELDS     => $payload,
+    CURLOPT_HTTPHEADER     => $headers,
+    CURLOPT_HTTPAUTH       => CURLAUTH_BASIC,
+    CURLOPT_USERPWD        => "$username:$password"
+  ));
+  $body  = curl_exec($ch);
+  $error = curl_error($ch);
+  curl_close($ch);
 
+  if ($body === false) {
+    fwrite(STDERR, "request failed: $error\n");
+    exit(1);
+  }
 
-  return $response->body;
+  return json_decode($body);
 }
 
 $arguments = array(
   'name'        => 'myTiff',
-  'description' => 'nothing special',
-  'file_name'   => '@/home/data/Desktop/ict-innovations/all_test-data/fax.pdf'
+  'description' => 'nothing special'
 );
 
 $files = array(

--- a/tests/get.php
+++ b/tests/get.php
@@ -1,8 +1,9 @@
 <?php
 
-require(__DIR__ . '/../vendor/nategood/httpful/bootstrap.php');
+// Uses ext-curl directly. This used to pull in nategood/httpful, which has no
+// PHP 8 release and was only ever needed by these two example scripts.
 
-// STEP 1: configure API function to connect and authenticate with ICTBroadcast server
+// STEP 1: configure API function to connect and authenticate with ICTCore server
 function ictcore_api($method) {
   $api_url  = 'http://core.voip.vision';
   $username = 'admin';
@@ -10,12 +11,23 @@ function ictcore_api($method) {
   $service_url = "$api_url/$method";
   echo $service_url."\n";
 
-  $response = \Httpful\Request::get($service_url) // Build a PUT request...
-      ->expectsJson()                             // we are receiving in json
-      ->authenticateWith($username, $password)    // authenticate with basic auth...
-      ->send(); 
+  $ch = curl_init($service_url);
+  curl_setopt_array($ch, array(
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER     => array('Accept: application/json'),
+    CURLOPT_HTTPAUTH       => CURLAUTH_BASIC,
+    CURLOPT_USERPWD        => "$username:$password"
+  ));
+  $body  = curl_exec($ch);
+  $error = curl_error($ch);
+  curl_close($ch);
 
-  return $response->body;
+  if ($body === false) {
+    fwrite(STDERR, "request failed: $error\n");
+    exit(1);
+  }
+
+  return json_decode($body);
 }
 
 $request = end($argv);


### PR DESCRIPTION
## Why

Every direct dependency was capped below PHP 8, so ICTCore could not be installed on a supported PHP at all. The versions it pinned also carry published security advisories, which composer 2.9+ refuses to resolve without `policy.advisories.block=false`. Both problems have the same fix.

## What moved

| was | now |
|---|---|
| swiftmailer 5.4 (end of life) | symfony/mailer 6.4 |
| twig 1.35 | twig 3 |
| firebase/php-jwt (CVE-2025-45769 affects < 7.0) | 7.x |
| dompdf 0.8 | dompdf 3.x |
| aza/thread (no PHP 8 release, unmaintained) | pcntl directly |

Dropped as unreferenced: ProcessManager, office-converter, nategood/httpful.

## The parts that were not import swaps

- **`Forgot_password`** — symfony's `send()` returns void and throws on failure, where Swift returned a recipient count. The existing truthiness check would have reported every successful send as a failure.
- **`Token`** — Twig 3 moved `setEscaper` onto `EscaperExtension`, but still passes the `Environment` as the callable's first argument, so the json escaper keeps three parameters and its byte-for-byte output.
- **`CoreThread`** — forks with `pcntl_fork`, reaps with `SIGCHLD` set to `SIG_IGN`, and runs inline when pcntl is unavailable or the SAPI is not cli.

Also fixed: a duplicate `FAILED_STATUS` constant in `Transmission` that was a hard syntax error on 8.x, and a `SignatureInvalidException` caught in `Forgot_password` without ever being imported, which would have fataled on any invalid token.

## Verified on PHP 8.3

151 files lint clean; all migrated classes load; twig escaper output unchanged; JWT round trips under HS256 and RS256 with expiry enforced; symfony/mime accepts the bracketed-IP addresses `validate_email()` produces; CoreThread forks three children into distinct pids leaving no zombies; `composer audit` reports no advisories across the resulting 24 packages.

Built and run end to end in the ICTFax container on the Remi 8.3 stream: dashboard serves, FreeSWITCH profile registers, and an SMTP message delivered through `SendmailTransport` lands in the ictcore mailbox.

## Before merging

`ictcore.spec` requires `php` unversioned, so an RPM build picks up whatever module stream the host has enabled. Raising the floor to 8.1 means ICTPBX and ICTDialer builds need `php:remi-8.3` enabled too. That coordination is why this is a branch rather than a direct push.